### PR TITLE
fixing the issue with the issue template

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -4,7 +4,7 @@
 ________________________________________________________________________________________________________________________________________
 ________________________________________________________________________________________________________________________________________
 Guide to issues:
- - Text in between <!-- and --> is not visible. It serves to guide you through the blueprint. Leave it as is.
+ - Text in between \<!-- and --\> (Ignore the backlash on this example) is not visible. It serves to guide you through the blueprint. Leave it as is.
 1) Specify to which type of Faction the problem in question belongs. If the issue can happen to only one faction, remove the arrows before and
 after that faction's name below. If the issue CAN happen on both sides, remove both arrows.
 ________________________________________________________________________________________________________________________________________


### PR DESCRIPTION
Due to a comment being closed before it should, the commented text was displayed accidentaly.