### PR TITLE
fix: Prevent closing non-linked CC issues

### DIFF
--- a/.github/workflows/close-referenced-issues.yml
+++ b/.github/workflows/close-referenced-issues.yml
@@ -20,14 +20,14 @@ jobs:
           # Fetch the last 20 closed issues from the external repo
           CLOSED_ISSUES=$(gh issue list -R "$REPO_OWNER/$SOURCE_REPO" --state closed --limit 20 --json number,body)
 
-          echo "Checking issues..."            
+          echo "Checking issues..."
           # Process only if JSON is valid
           echo "$CLOSED_ISSUES" | jq -c '.[]' | while read -r issue; do
             ISSUE_NUMBER=$(echo "$issue" | jq -r '.number')
             BODY=$(echo "$issue" | jq -r '.body')
 
             # Extract issue references (eg. https://github.com/$OUR_OWNER/$OUR_REPO/issues/123)
-            REFERENCES=$(echo "$BODY" | grep -oE "https://github.com/$OUR_OWNER/$OUR_REPO/issues/[0-9]+" | grep -oE '[0-9]+$' || true)
+            REFERENCES=$(echo "$BODY" | head -n 10 | grep -oE "https://github.com/$OUR_OWNER/$OUR_REPO/issues/[0-9]+" | grep -oE '[0-9]+$' || true)
 
             # Skip if no references are found
             if [[ -z "$REFERENCES" ]]; then


### PR DESCRIPTION
The bot closes any CC issue that is referenced in an AC issue

Issues that should be closed are linked near the top of the page with some kind of text near the top of the page ("Issue linked from CC " or "Original CC Report" or "Original CC issue")

This prevents accidently closing CC issues that are linked further down the body

tests:
[AC issue 22003](https://github.com/azerothcore/azerothcore-wotlk/issues/22003) [issue.json](https://github.com/user-attachments/files/20004653/issue.json)

```
ISSUE_NUMBER=$(jq -r '.number' issue.json)
BODY=$(jq -r '.body' issue.json)
OUR_OWNER="chromiecraft"
OUR_REPO="chromiecraft"
REFERENCES=$(echo "$BODY" | grep -oE "https://github.com/$OUR_OWNER/$OUR_REPO/issues/[0-9]+" | grep -oE '[0-9]+$' || true)\n
```
See `REFERENCES` only contains 1 value


