### PR TITLE
fix: add sort:updated-desc to close-referenced-issues action

### DIFF
--- a/.github/workflows/close-referenced-issues.yml
+++ b/.github/workflows/close-referenced-issues.yml
@@ -18,7 +18,7 @@ jobs:
           OUR_REPO: "chromiecraft"
         run: |
           # Fetch the last 20 closed issues from the external repo
-          CLOSED_ISSUES=$(gh issue list -R "$REPO_OWNER/$SOURCE_REPO" --state closed --limit 20 --json number,body)
+          CLOSED_ISSUES=$(gh issue list -R "$REPO_OWNER/$SOURCE_REPO" --state closed --search "sort:updated-desc" --limit 20 --json number,body)
 
           echo "Checking issues..."
           # Process only if JSON is valid


### PR DESCRIPTION
currently 3 issues are not beeing closed

https://github.com/chromiecraft/chromiecraft/issues/7862
https://github.com/chromiecraft/chromiecraft/issues/7792
https://github.com/chromiecraft/chromiecraft/issues/7786

best guess is that it's the same problem that existed in the ac-wiki github action, which required to order the checked issues beeing ordered descending by latest change.

https://github.com/azerothcore/wiki/blob/45ff33629c7a99a1ac776b8b513a6a2b5a1fd137/.github/workflows/requires-wiki-update-check.yml#L20

imo this could be the cause for "old" issues not getting closed properly.